### PR TITLE
Bump to latest riddley (0.1.7)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "local. mutable. variables."
   :license {:name "MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[riddley "0.1.4"]]
+  :dependencies [[riddley "0.1.7"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.5.1"]
                                   [criterium "0.4.1"]]}}
   :java-source-paths ["src"]

--- a/test/proteus_test.clj
+++ b/test/proteus_test.clj
@@ -18,7 +18,7 @@
         (let-mutable [x true]
           (set! x (not x))
           x)))
-  
+
   (is (= 100
         (let-mutable [x 0]
           (dotimes [_ 100]
@@ -64,18 +64,23 @@
   (is (= 3 (let-mutable [x 3]
              (case x
                3 3))))
-  
+
   (is (= [0 :x]
         (let-mutable [x 0] [x :x])))
-  
+
   (is (= #{0 :x}
         (let-mutable [x 0] #{x :x})))
-  
+
   (is (= {0 1 :x :y}
         (let-mutable [x 0 y 1] {x y :x :y})))
-  
+
   (is (= (Test. nil)
-        (let-mutable [x 0] #proteus_test.Test{:x nil}))))
+        (let-mutable [x 0] #proteus_test.Test{:x nil})))
+
+  (is (= :f1-result
+         (let-mutable [x 0]
+           (letfn [(f1 [] :f1-result)]
+             (let [f2 f1] (f2)))))))
 
 (deftest ^:benchmark benchmark-sum
   (c/quick-bench


### PR DESCRIPTION
This is _a_ fix for #3 - potentially the wrong one, but bumping riddley can't hurt, right?

The actual issue: `letfn` isn't having its locals registered as part of the `letfn*` transformation, so its bindings aren't visible to the analyzer inside nested `let` expressions. So swallowing analysis errors as riddley 0.1.7 gets this use case working, but I'm assuming the right fix is to register locals for `letfn`. 

In digging into a potential locals-registering solution, my quicky & easy (but dirty, poking at internals) idea:

``` diff
diff --git a/src/proteus.clj b/src/proteus.clj
index 7eadb2e..d73b710 100644
--- a/src/proteus.clj
+++ b/src/proteus.clj
@@ -50,7 +50,9 @@
             vs' (map #(gensym (name %)) vs)]
         `(let [~@(interleave vs' vs)
                ~@(interleave vs (map read-form vs))]
-           (~'letfn* ~bindings
+           (~'letfn* ~(#'riddley.walk/let-bindings
+                        transform-let-mutable-form
+                        bindings)
              (let [~@(interleave vs vs')]
                ~(transform-let-mutable-form `(do ~@body))))))
```

didn't work, got a `java.lang.UnsupportedOperationException: Can't type hint a primitive local`. 

Surprisingly (to me), inlining the implementation of `let-bindings` seemed to do the trick:

``` diff
diff --git a/src/proteus.clj b/src/proteus.clj
index 7eadb2e..39b1c98 100644
--- a/src/proteus.clj
+++ b/src/proteus.clj
@@ -50,7 +50,14 @@
             vs' (map #(gensym (name %)) vs)]
         `(let [~@(interleave vs' vs)
                ~@(interleave vs (map read-form vs))]
-           (~'letfn* ~bindings
+           (~'letfn* ~(->> bindings
+                           (partition-all 2)
+                           (mapcat
+                             (fn [[k v]]
+                               (let [[k v] [k (transform-let-mutable-form v)]]
+                                 (riddley.compiler/register-local k v))
+                               [k v]))
+                           vec)
              (let [~@(interleave vs vs')]
                ~(transform-let-mutable-form `(do ~@body))))))
```

But that seemed pretty awful, and might not even be necessary - I don't have a full mental model of the consequences of analysis errors in this context.
